### PR TITLE
Add guard for missing Instance/Static binding flags in TypeData.IsValidMember

### DIFF
--- a/BionicCode.Net/BionicCode.Utilities.Net.Common/Extensions/TypeData.cs
+++ b/BionicCode.Net/BionicCode.Utilities.Net.Common/Extensions/TypeData.cs
@@ -199,6 +199,10 @@ namespace BionicCode.Utilities.Net
 
         private bool IsValidMember(BindingFlags bindingFlags, PropertyData cachedPropertyData)
         {
+            if (!bindingFlags.HasFlag(BindingFlags.Instance) && !bindingFlags.HasFlag(BindingFlags.Static))
+            {
+                return false;
+            }
             if (bindingFlags.HasFlag(BindingFlags.Static) ^ cachedPropertyData.IsStatic)
             {
                 return false;


### PR DESCRIPTION
### Motivation
- Fix a behavior mismatch with `Type.GetProperties` by ensuring `TypeData.IsValidMember` rejects calls that specify neither `BindingFlags.Instance` nor `BindingFlags.Static` so member selection is explicit and predictable. [BUG] (see file change below).

### Description
- Added an early check in `TypeData.IsValidMember` to `return false` when neither `BindingFlags.Instance` nor `BindingFlags.Static` is present, implemented at the top of the method in `BionicCode.Net/BionicCode.Utilities.Net.Common/Extensions/TypeData.cs` around [L202-L205].
- Coverage / Call-tree traversal depth: searched for `IsValidMember` usages across the repo and inspected `TypeData.cs` to verify the change location and surrounding flag logic; no additional call paths required modification.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973431f2ec88324ba57109429298f40)